### PR TITLE
Attach collision groups to state (rather than being globals)

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -23,10 +23,6 @@ gScaleComponent = ScaleComponent()
 gUpdateComponent = UpdateComponent()
 gDrawComponent = DrawComponent()
 
--- create global collision
-gSolidGroup = CollisionGroup()
-gPlayerBullets = CollisionGroup()
-
 -- create state manager and load state modules
 gStateManager = StateManager()
 MenuState = require 'states.MenuState'

--- a/objects/Actor.lua
+++ b/objects/Actor.lua
@@ -1,7 +1,7 @@
 Rectangle = require "objects.Rectangle"
 
 -- ACTOR CLASS --
-local function Actor(x, y, w, h, ox, oy)
+local function Actor(game, x, y, w, h, ox, oy)
   local self = Rectangle(x, y, w, h)
   -- hitbox offset (optional)
   self.ox = ox or 0
@@ -21,7 +21,7 @@ local function Actor(x, y, w, h, ox, oy)
         --move and check for collisions
         local prevX = self.x
         self.x = self.x + sign
-        if not gSolidGroup.collideWith(self) then
+        if not game.solidGroup.collideWith(self) then
           --no collision, continue incrementing pixel by pixel
           dx = dx - sign
         else
@@ -47,7 +47,7 @@ local function Actor(x, y, w, h, ox, oy)
       while dy ~= 0 do
         local prevY = self.y
         self.y = self.y + sign
-        if not gSolidGroup.collideWith(self) then
+        if not game.solidGroup.collideWith(self) then
           dy = dy - sign
         else
           self.y = prevY

--- a/objects/Bullet.lua
+++ b/objects/Bullet.lua
@@ -1,8 +1,8 @@
 Actor = require 'objects.Actor'
 Vector2 = require 'tools.Vector2'
 
-local function Bullet()
-  local self = Actor(0, 0, 2, 2)
+local function Bullet(game)
+  local self = Actor(game, 0, 0, 2, 2)
 
   local _img = love.graphics.newImage('assets/img/bullet.png')
   local _speed = 60

--- a/objects/Player.lua
+++ b/objects/Player.lua
@@ -1,8 +1,8 @@
 Actor = require "objects.Actor"
 Bullet = require "objects.Bullet"
 
-local function Player()
-  local self = Actor(16, 24, 22, 15)
+local function Player(game)
+  local self = Actor(game, 16, 24, 22, 15)
 
   local _turret_img = love.graphics.newImage('assets/img/turret/r.png')
   local _base_img = love.graphics.newImage('assets/img/base/r.png')
@@ -13,9 +13,9 @@ local function Player()
   local _cooldown = .25
   local _fireTimer = 0
   for i = 1,5 do
-    local bullet = Bullet()
+    local bullet = Bullet(game)
     bullet.active = false
-    gPlayerBullets.add(bullet)
+    game.playerBullets.add(bullet)
   end
 
   gUpdateComponent.addUpdatable(self)
@@ -82,7 +82,7 @@ local function Player()
   end
 
   function self.fire()
-    local bullet = gPlayerBullets.getFirstInactive()
+    local bullet = game.playerBullets.getFirstInactive()
     if bullet == nil then return end
     bullet.fireAt(self.x + self.w / 2,
       self.y + self.h / 2,

--- a/objects/Solid.lua
+++ b/objects/Solid.lua
@@ -1,7 +1,7 @@
 Rectangle = require "objects.Rectangle"
 
 -- Solid tiles -- 
-local function Solid(x,y,w,h,img,ox,oy)
+local function Solid(game,x,y,w,h,img,ox,oy)
   local _ox = ox or 0
   local _oy = oy or 8
   local self = Rectangle(x,y,w,h)
@@ -9,7 +9,7 @@ local function Solid(x,y,w,h,img,ox,oy)
   local _img = love.graphics.newImage(img or "assets/img/block.png")
 
   gDrawComponent.addDrawable(self)
-  gSolidGroup.add(self)
+  game.solidGroup.add(self)
 
   function self.draw()
     love.graphics.draw(_img,self.x - _ox,self.y - _oy)

--- a/states/GameState.lua
+++ b/states/GameState.lua
@@ -1,15 +1,20 @@
 Player = require 'objects.Player'
 TileLoader = require 'tools.TileLoader'
+CollisionGroup = require 'tools.CollisionGroup'
 
 local function GameState()
-  local self = {}
+  local self = {
+    -- init collision groups
+    solidGroup = CollisionGroup(),
+    playerBullets = CollisionGroup(),
+  }
 
   -- load tiles
-  local _tileLoader = TileLoader()
+  local _tileLoader = TileLoader(self)
   _tileLoader.loadTiles()
 
   -- init player
-  local _player = Player()
+  local _player = Player(self)
 
   -- update and draw
   gUpdateComponent.addUpdatable(self)

--- a/tools/StateManager.lua
+++ b/tools/StateManager.lua
@@ -15,12 +15,10 @@ local function StateManager()
   function self.startState(key)
     -- reset draw and update components to clear current state
     gDrawComponent.reset()
-    gCursor = Cursor()
     gUpdateComponent.reset()
 
-    -- reset collision groups
-    gSolidGroup.reset()
-    gPlayerBullets.reset()
+    -- reset cursor
+    gCursor = Cursor()
 
     -- create instance of new state
     -- (this adds it to components)

--- a/tools/TileLoader.lua
+++ b/tools/TileLoader.lua
@@ -1,13 +1,13 @@
 Solid = require 'objects.Solid'
 
-local function TileLoader()
+local function TileLoader(game)
   local self = {}
 
   function self.loadTiles()
     for x = 0,19 do
       for y = 0, 14 do
         if x == 0 or x == 19 or y == 0 or y == 14 or math.random() < 0.05 then
-          Solid(x*16, y*16 + 8, 16, 16)
+          Solid(game,x*16, y*16 + 8, 16, 16)
         end
       end
     end


### PR DESCRIPTION
I felt weird about making collision groups globals that we had to reset every time we changed states.  It makes more sense to have the solids group and the player bullets group be attached to the "game" state, to me anyway.  And that matches the workflow we had with Phaser when we were working on trace.
